### PR TITLE
add kms permission for loki to acess encrypted bucket

### DIFF
--- a/modules/loki-stack/iam-policies.tf
+++ b/modules/loki-stack/iam-policies.tf
@@ -23,6 +23,19 @@ data "aws_iam_policy_document" "loki" {
       "${aws_s3_bucket.loki[0].arn}/*",
     ]
   }
+
+  statement {
+    sid     = "AllowKMS"
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    effect = "Allow"
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "loki" {


### PR DESCRIPTION
@tom-weiss-github @ashleshshrivastava @ursuciprian 

Changes for loki bucket to access kms...
Once this is merged, we will have to update module version in testing-eks-cluster and other repos and apply the changes..